### PR TITLE
Adding initial benchmarking analysis

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,6 @@
+{
+  "presets": ["es2015", "stage-0", "react"],
+  "plugins": [
+    ["transform-decorators-legacy"]
+  ]
+}

--- a/benchmarks/components.js
+++ b/benchmarks/components.js
@@ -1,0 +1,49 @@
+import React, { Component } from 'react';
+
+import { autobind } from 'core-decorators';
+import reactbind from '../src/';
+
+export const CreateClassVersion = React.createClass({
+    fn1: function() {},
+    fn2: function() {},
+    fn3: function() {},
+    render: function() {
+        return <div onClick={this.fn1}>Hello world</div>;
+    }
+});
+
+export class ES6ConstructorBindVersion extends Component {
+    constructor() {
+        super();
+        this.fn1 = this.fn1.bind(this);
+        this.fn2 = this.fn2.bind(this);
+        this.fn3 = this.fn3.bind(this);
+    }
+
+    fn1() {}
+    fn2() {}
+    fn3() {}
+    render() {
+        return <div onClick={this.fn1}>Hello world</div>;
+    }
+}
+
+@autobind()
+export class AutobindVersion extends Component {
+    fn1() {}
+    fn2() {}
+    fn3() {}
+    render() {
+        return <div onClick={this.fn1}>Hello world</div>;
+    }
+}
+
+@reactbind()
+export class ReactBindVersion extends Component {
+    fn1() {}
+    fn2() {}
+    fn3() {}
+    render() {
+        return <div onClick={this.fn1}>Hello world</div>;
+    }
+}

--- a/benchmarks/index.js
+++ b/benchmarks/index.js
@@ -1,0 +1,2 @@
+require('babel-register');
+require('./runner.js');

--- a/benchmarks/runner.js
+++ b/benchmarks/runner.js
@@ -1,0 +1,30 @@
+import React from 'react';
+import ReactDOMServer from 'react-dom/server';
+import Benchmark from "benchmark";
+import {
+    CreateClassVersion,
+    ES6ConstructorBindVersion,
+    AutobindVersion,
+    ReactBindVersion,
+} from "./components";
+
+function test(Component) {
+    return () => {
+        ReactDOMServer.renderToString(<Component />);
+    }
+}
+
+function onComplete() {
+    this.forEach(benchmark => {
+        console.log(benchmark.name);
+        console.log(`    Average:    ${Math.round(benchmark.stats.mean * 1000000)} us`);
+    });
+}
+
+Benchmark.Suite({ })
+    .add('CreateClassVersion', test(CreateClassVersion))
+    .add('ES6ConstructorBindVersion', test(ES6ConstructorBindVersion))
+    .add('AutobindVersion', test(AutobindVersion))
+    .add('ReactBindVersion', test(ReactBindVersion))
+    .on("complete", onComplete)
+    .run();

--- a/example/webpack.config.js
+++ b/example/webpack.config.js
@@ -18,7 +18,10 @@ module.exports = {
             {
                 test: /\.js$/,
                 loader: 'babel',
-                query: { stage: 0 },
+                query: {
+                    presets: ['es2015', 'stage-0', 'react'],
+                    plugins: ['transform-decorators-legacy' ]
+                },
             },
         ]
     },

--- a/package.json
+++ b/package.json
@@ -5,15 +5,23 @@
   "jsnext:main": "src/react-bind-decorator.js",
   "scripts": {
     "start": "cd example && node server.js",
+    "benchmark": "NODE_ENV=production node benchmarks/index.js"
   },
   "devDependencies": {
-    "babel": "^5.6.14",
-    "babel-core": "^5.6.15",
-    "babel-loader": "^5.2.2",
+    "babel": "^6.5.2",
+    "babel-core": "^6.7.4",
+    "babel-loader": "^6.2.4",
+    "babel-plugin-transform-decorators-legacy": "^1.3.4",
+    "babel-polyfill": "^6.7.4",
+    "babel-preset-es2015": "^6.6.0",
+    "babel-preset-react": "^6.5.0",
+    "babel-preset-stage-0": "^6.5.0",
+    "babel-register": "^6.7.2",
+    "benchmark": "^2.1.0",
+    "core-decorators": "^0.12.0",
     "react": "^0.14.8",
     "react-dom": "^0.14.8",
     "react-hot-loader": "^1.3.0",
-    "rimraf": "^2.4.4",
     "webpack": "^1.12.13",
     "webpack-dev-server": "^1.14.1"
   },
@@ -28,9 +36,12 @@
   },
   "keywords": [
     "react",
-    "react-component"
+    "es2016",
+    "es7",
+    "decorators",
+    "decorator"
   ],
-  "author": "Zack Argyle <zackargyle@pinterest.com> (http://zackargyle.com)",
+  "author": "Zack Argyle <zack.argyle@github.com> (http://zackargyle.com)",
   "license": "ISC",
   "bugs": {
     "url": "https://github.com/zackargyle/react-image-layout/"

--- a/src/react-bind-decorator.js
+++ b/src/react-bind-decorator.js
@@ -28,10 +28,8 @@ function isFunction(fn) {
  * @param {Object} target - the root object
  * @param {string} method - an object attribute
  */
-function isNotReactMethod(target) {
-    return (method) => {
-        return isFunction(target.prototype[method]) && !REACT_METHODS[method];
-    }
+function isNotReactMethod(target, method) {
+    return isFunction(target.prototype[method]) && !REACT_METHODS[method];
 }
 
 /*
@@ -41,16 +39,18 @@ function isNotReactMethod(target) {
  */
 function bindMethod(target) {
     return (method) => {
-        const fn = target.prototype[method];
-        let boundFn = null;
-        Object.defineProperty(target.prototype, method, {
-            get() {
-                if (!boundFn) {
-                    boundFn = fn.bind(this);
+        if (isNotReactMethod(target, method)) {
+            const fn = target.prototype[method];
+            let boundFn = null;
+            Object.defineProperty(target.prototype, method, {
+                get() {
+                    if (!boundFn) {
+                        boundFn = fn.bind(this);
+                    }
+                    return boundFn;
                 }
-                return boundFn;
-            }
-        });
+            });
+        }
     };
 }
 
@@ -62,7 +62,6 @@ function bindMethod(target) {
 export default function bind() {
     return function(target) {
         Object.getOwnPropertyNames(target.prototype)
-              .filter(isNotReactMethod(target))
               .forEach(bindMethod(target))
     };
 }


### PR DESCRIPTION
- Adding `npm run benchmark` to compare average render time of various component implementations
- Updating Babel to 6.X and using the legacy decorator plugin.
- Remove .filter so we don't have to iterate twice.
