### PR TITLE
Added typescript typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,2 @@
+export default reactbind;
+declare function reactbind(): ClassDecorator;


### PR DESCRIPTION
Now typescript projects compile fine even with 'noImplicitAny' (tsconfig.json) and 'no-any' (tslint.json) options turned on.

Fixes #5 

By the way, why do you wrap the function in another one? Can't you just `export bind(target) {...}`? It is simpler, and I do not see any reason to encapsulate it in another function.