### PR TITLE
Reference the typings file in package.json; ignore methods from the new lifecycle API

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A decorator to bind only unique component methods",
   "jsnext:main": "src/react-bind-decorator.js",
   "main": "src/react-bind-decorator.js",
+  "types": "./index.d.ts",
   "scripts": {
     "start": "cd example && node server.js",
     "benchmark": "NODE_ENV=production node benchmarks/index.js"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "A decorator to bind only unique component methods",
   "jsnext:main": "src/react-bind-decorator.js",
   "main": "src/react-bind-decorator.js",
-  "types": "./index.d.ts",
+  "types": "src/index.d.ts",
   "scripts": {
     "start": "cd example && node server.js",
     "benchmark": "NODE_ENV=production node benchmarks/index.js"

--- a/src/react-bind-decorator.js
+++ b/src/react-bind-decorator.js
@@ -10,6 +10,8 @@ const REACT_METHODS = {
     componentWillUpdate: true,
     componentDidUpdate: true,
     componentWillUnmount: true,
+    getSnapshotBeforeUpdate: true,
+    componentDidCatch: true,
     isMounted: true,
     render: true,
     replaceProps: true,


### PR DESCRIPTION
I expected the new commit to appear bellow the comments in #6 but it didn't. And so that the PR isn't too small, I added the methods from the new React API: https://reactjs.org/docs/react-component.html to the ignore list.

I don't want to mess up your version management, feel free to commit in this PR to change it if you want.